### PR TITLE
change URL for downloading get-pip.py

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -18,7 +18,7 @@ HOME=/opt/app-root
 
 # Install pip for Python 2.7.
 
-curl -s -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
+curl -s -o /tmp/get-pip.py https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py
 
 /usr/bin/python /tmp/get-pip.py --user
 


### PR DESCRIPTION
change URL to raw GitHub URL for downloading get-pip.py 
because of the outage on https://bootstrap.pypa.io/get-pip.py